### PR TITLE
fix(backend): urgent fix invalid global css file

### DIFF
--- a/apps/backend/src/routes/+layout.svelte
+++ b/apps/backend/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script>
-	import '../app.postcss';
+	import '../app.css';
 	import { authStore } from '$lib/stores';
 
 	// Preload auth state


### PR DESCRIPTION
Missed a bug in the `+layout.svelte` file where `app.css` was referenced as `app.postcss`, which is incorrect.