### PR TITLE
fix(functions-gcp): fix eslint find tsconfig error

### DIFF
--- a/packages/functions-gcp/.eslintrc.js
+++ b/packages/functions-gcp/.eslintrc.js
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 module.exports = {
   root: true,
   env: {
@@ -15,6 +17,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: ["tsconfig.json", "tsconfig.dev.json"],
+    tsConfigRootDir: path.join(__dirname, 'packages', 'functions-gcp'),
     sourceType: "module",
   },
   ignorePatterns: [

--- a/packages/functions-gcp/.gitignore
+++ b/packages/functions-gcp/.gitignore
@@ -8,4 +8,4 @@ typings/
 node_modules/
 
 # Firebase Emulator Data
-firebase-export/
+firebase-export*/


### PR DESCRIPTION
1. Fixed an ESLint IDE error where it could not locate `tsconfig.json` from monorepo